### PR TITLE
Improve audit logging for character and group events

### DIFF
--- a/models/enums.py
+++ b/models/enums.py
@@ -129,7 +129,13 @@ class CharacterAuditAction(Enum):
     STATUS_CHANGE = "status_change"
     SKILL_CHANGE = "skill_change"
     REPUTATION_CHANGE = "reputation_change"
-    FUNDS_SPENT = "funds_spent"
+    FUNDS_ADDED = "funds_added"
+    FUNDS_REMOVED = "funds_removed"
+    FUNDS_SET = "funds_set"
+    GROUP_JOINED = "group_joined"
+    GROUP_LEFT = "group_left"
+    CONDITION_CHANGE = "condition_change"
+    CYBERNETICS_CHANGE = "cybernetics_change"
 
     @classmethod
     def descriptions(cls):
@@ -139,7 +145,13 @@ class CharacterAuditAction(Enum):
             cls.STATUS_CHANGE.value: "Status Changed",
             cls.SKILL_CHANGE.value: "Skills Modified",
             cls.REPUTATION_CHANGE.value: "Reputation Changed",
-            cls.FUNDS_SPENT.value: "Funds Spent",
+            cls.FUNDS_ADDED.value: "Funds Added",
+            cls.FUNDS_REMOVED.value: "Funds Removed",
+            cls.FUNDS_SET.value: "Funds Set",
+            cls.GROUP_JOINED.value: "Joined Group",
+            cls.GROUP_LEFT.value: "Left Group",
+            cls.CONDITION_CHANGE.value: "Condition Changed",
+            cls.CYBERNETICS_CHANGE.value: "Cybernetic Changed",
         }
 
 
@@ -153,6 +165,7 @@ class GroupAuditAction(Enum):
     MEMBER_LEFT = "member_left"
     FUNDS_ADDED = "funds_added"
     FUNDS_WITHDRAWN = "funds_withdrawn"
+    FUNDS_SET = "funds_set"
     DISBANDED = "disbanded"
 
     @classmethod
@@ -167,6 +180,7 @@ class GroupAuditAction(Enum):
             cls.MEMBER_LEFT.value: "Member Left",
             cls.FUNDS_ADDED.value: "Funds Added",
             cls.FUNDS_WITHDRAWN.value: "Funds Withdrawn",
+            cls.FUNDS_SET.value: "Funds Set",
             cls.DISBANDED.value: "Disbanded",
         }
 

--- a/models/tools/group.py
+++ b/models/tools/group.py
@@ -63,7 +63,7 @@ class Group(db.Model):
         audit_log = GroupAuditLog(
             group_id=self.id,
             editor_user_id=editor_user_id,
-            action=GroupAuditAction.FUNDS_REMOVED,
+            action=GroupAuditAction.FUNDS_WITHDRAWN,
             changes=f"Removed {amount} for {reason}",
         )
         db.session.add(audit_log)

--- a/routes/tools/groups.py
+++ b/routes/tools/groups.py
@@ -148,9 +148,17 @@ def edit_group_post(group_id):
     changes = []
     if group.name != name:
         changes.append(f"Name changed from '{group.name}' to '{name}'")
-    old_type_str = getattr(group.type, "value", group.type)
-    if old_type_str != type:
-        changes.append(f"Type changed from '{old_type_str}' to '{type}'")
+
+    # Only allow type changes for admins
+    if (
+        current_user.has_role(Role.USER_ADMIN.value)
+        and type
+        and getattr(group.type, "value", group.type) != type
+    ):
+        changes.append(
+            f"Type changed from '{getattr(group.type, 'value', group.type)}' to '{type}'"
+        )
+        group.type = type
 
     # Handle bank account changes using centralized methods
     if current_user.has_role(Role.USER_ADMIN.value):
@@ -158,7 +166,6 @@ def edit_group_post(group_id):
             group.set_funds(bank_account, current_user.id, "Admin group edit")
 
     group.name = name
-    group.type = type
 
     # Create audit log if there were changes
     if changes:
@@ -519,16 +526,24 @@ def edit_group_admin_post(group_id):
     changes = []
     if group.name != name:
         changes.append(f"Name changed from '{group.name}' to '{name}'")
-    old_type_str = getattr(group.type, "value", group.type)
-    if old_type_str != type:
-        changes.append(f"Type changed from '{old_type_str}' to '{type}'")
+
+    # Only allow type changes for admins
+    if (
+        current_user.has_role(Role.USER_ADMIN.value)
+        and type
+        and getattr(group.type, "value", group.type) != type
+    ):
+        changes.append(
+            f"Type changed from '{getattr(group.type, 'value', group.type)}' to '{type}'"
+        )
+        group.type = type
 
     # Handle bank account changes using centralized methods
-    if group.bank_account != bank_account_int:
-        group.set_funds(bank_account_int, current_user.id, "Admin group edit")
+    if current_user.has_role(Role.USER_ADMIN.value):
+        if group.bank_account != bank_account_int:
+            group.set_funds(bank_account_int, current_user.id, "Admin group edit")
 
     group.name = name
-    group.type = type
 
     # Update samples
     if sample_ids:

--- a/routes/tools/groups.py
+++ b/routes/tools/groups.py
@@ -2,9 +2,9 @@ from flask import Blueprint, abort, flash, redirect, render_template, request, u
 from flask_login import current_user, login_required
 
 from models.database.sample import Sample
-from models.enums import CharacterStatus, GroupAuditAction, GroupType, Role
+from models.enums import CharacterAuditAction, CharacterStatus, GroupAuditAction, GroupType, Role
 from models.extensions import db
-from models.tools.character import Character
+from models.tools.character import Character, CharacterAuditLog
 from models.tools.group import Group, GroupAuditLog, GroupInvite
 from utils.decorators import (
     email_verified_required,
@@ -148,28 +148,17 @@ def edit_group_post(group_id):
     changes = []
     if group.name != name:
         changes.append(f"Name changed from '{group.name}' to '{name}'")
-
-    old_bank_account = group.bank_account
     old_type_str = getattr(group.type, "value", group.type)
+    if old_type_str != type:
+        changes.append(f"Type changed from '{old_type_str}' to '{type}'")
+
+    # Handle bank account changes using centralized methods
+    if current_user.has_role(Role.USER_ADMIN.value):
+        if group.bank_account != bank_account:
+            group.set_funds(bank_account, current_user.id, "Admin group edit")
 
     group.name = name
-
-    if current_user.has_role(Role.USER_ADMIN.value):
-        if type and old_type_str != type:
-            changes.append(f"Type changed from '{old_type_str}' to '{type}'")
-            group.type = type
-        if bank_account is not None:
-            try:
-                new_bank_account = int(bank_account)
-                if old_bank_account != new_bank_account:
-                    if new_bank_account > old_bank_account:
-                        changes.append(f"Funds added: {new_bank_account - old_bank_account}")
-                    else:
-                        changes.append(f"Funds withdrawn: {old_bank_account - new_bank_account}")
-                group.bank_account = new_bank_account
-            except ValueError:
-                flash("Bank account must be a number", "error")
-                return redirect(url_for("groups.group_list"))
+    group.type = type
 
     # Create audit log if there were changes
     if changes:
@@ -275,7 +264,7 @@ def respond_to_invite_post(invite_id):
     if action == "accept":
         character.group_id = invite.group_id
 
-        # Create audit log for member joining
+        # Create audit log for member joining (group audit)
         audit_log = GroupAuditLog(
             group_id=invite.group_id,
             editor_user_id=current_user.id,
@@ -283,6 +272,17 @@ def respond_to_invite_post(invite_id):
             changes=f"Member joined: {character.name}",
         )
         db.session.add(audit_log)
+
+        # Create audit log for character joining group (character audit)
+        from models.enums import CharacterAuditAction
+
+        character_audit = CharacterAuditLog(
+            character_id=character.id,
+            editor_user_id=current_user.id,
+            action=CharacterAuditAction.GROUP_JOINED.value,
+            changes=f"Joined group: {invite.group.name}",
+        )
+        db.session.add(character_audit)
 
         flash(f"You have joined {invite.group.name}.", "success")
         GroupInvite.query.filter_by(character_id=character.id).delete()
@@ -322,7 +322,7 @@ def leave_group_post(group_id):
         flash("You are not a member of this group", "error")
         return redirect(url_for("groups.group_list", character_id=character_id))
 
-    # Create audit log for member leaving
+    # Create audit log for member leaving (group audit)
     audit_log = GroupAuditLog(
         group_id=group.id,
         editor_user_id=current_user.id,
@@ -330,6 +330,17 @@ def leave_group_post(group_id):
         changes=f"Member left: {character.name}",
     )
     db.session.add(audit_log)
+
+    # Create audit log for character leaving group (character audit)
+    from models.enums import CharacterAuditAction
+
+    character_audit = CharacterAuditLog(
+        character_id=character.id,
+        editor_user_id=current_user.id,
+        action=CharacterAuditAction.GROUP_LEFT.value,
+        changes=f"Left group: {group.name}",
+    )
+    db.session.add(character_audit)
 
     character.group_id = None
     db.session.commit()
@@ -401,6 +412,15 @@ def remove_character(group_id, character_id):
         changes=f"Member removed by admin: {character.name}",
     )
     db.session.add(audit_log)
+
+    # Create audit log for character being removed from group (character audit)
+    character_audit = CharacterAuditLog(
+        character_id=character.id,
+        editor_user_id=current_user.id,
+        action=CharacterAuditAction.GROUP_LEFT.value,
+        changes=f"Removed from group by admin: {group.name}",
+    )
+    db.session.add(character_audit)
 
     character.group_id = None
     db.session.commit()
@@ -502,15 +522,13 @@ def edit_group_admin_post(group_id):
     old_type_str = getattr(group.type, "value", group.type)
     if old_type_str != type:
         changes.append(f"Type changed from '{old_type_str}' to '{type}'")
+
+    # Handle bank account changes using centralized methods
     if group.bank_account != bank_account_int:
-        if bank_account_int > group.bank_account:
-            changes.append(f"Funds added: {bank_account_int - group.bank_account}")
-        else:
-            changes.append(f"Funds withdrawn: {group.bank_account - bank_account_int}")
+        group.set_funds(bank_account_int, current_user.id, "Admin group edit")
 
     group.name = name
     group.type = type
-    group.bank_account = bank_account_int
 
     # Update samples
     if sample_ids:

--- a/routes/tools/messages.py
+++ b/routes/tools/messages.py
@@ -83,7 +83,9 @@ def send_message():
 
     # Deduct funds only after the message is successfully created
     if not paid_in_cash:
-        sender.spend_funds(10, editor_user_id=current_user.id, reason="Send message")
+        sender.remove_funds(
+            10, editor_user_id=current_user.id, reason=f"Sent message to {recipient_name}"
+        )
 
     db.session.commit()
 


### PR DESCRIPTION
- Refactor character edit_post to use specific audit action types (EDIT, CONDITION_CHANGE, CYBERNETICS_CHANGE) instead of lumping all changes together
- Fix downtime methods to use centralized fund management (add_funds, remove_funds) for proper audit logging
- Ensure all character and group fund changes are properly logged in audit system
- Update character edit_post to create separate audit logs for different types of changes
- Fix enter_pack_contents_post and process_downtime to use centralized fund methods

Fixes # (issue)
