### PR TITLE
Fix: Only log reputation changes when values actually change

### DIFF
--- a/models/tools/character.py
+++ b/models/tools/character.py
@@ -358,16 +358,17 @@ class Character(db.Model):
             )
             db.session.add(reputation)
 
-        # Log the change
-        log = CharacterAuditLog(
-            character_id=self.id,
-            editor_user_id=editor_user_id,
-            action=CharacterAuditAction.REPUTATION_CHANGE,
-            changes=(
-                f"Reputation with faction {faction_id} changed from {old_value} " f"to {value}"
-            ),
-        )
-        db.session.add(log)
+        # Only log the change if the value actually changed
+        if old_value != value:
+            log = CharacterAuditLog(
+                character_id=self.id,
+                editor_user_id=editor_user_id,
+                action=CharacterAuditAction.REPUTATION_CHANGE,
+                changes=(
+                    f"Reputation with faction {faction_id} changed from {old_value} " f"to {value}"
+                ),
+            )
+            db.session.add(log)
 
         return True
 


### PR DESCRIPTION
- Modified set_reputation method to only create audit logs when reputation values change
- Added test to verify no audit logs are created for unchanged reputation values
- Fixes issue where all reputations appeared in audit log during character edits even when unchanged

Fixes # (issue)
