### PR TITLE
Add inactive groups feature

### DIFF
--- a/migrations/versions/add_is_active_to_group.py
+++ b/migrations/versions/add_is_active_to_group.py
@@ -1,0 +1,28 @@
+"""add_is_active_to_group
+
+Revision ID: add_is_active_to_group
+Revises: merge_heads
+Create Date: 2025-01-27
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "add_is_active_to_group"
+down_revision = ("add_notify_message_responded_column", "add_dark_mode_column")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add is_active column to group table
+    op.add_column(
+        "group", sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true())
+    )
+
+
+def downgrade():
+    # Remove is_active column from group table
+    op.drop_column("group", "is_active")

--- a/migrations/versions/merge_heads.py
+++ b/migrations/versions/merge_heads.py
@@ -11,7 +11,11 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "merge_heads"
-down_revision = ("add_notify_message_responded_column", "add_dark_mode_column")
+down_revision = (
+    "add_notify_message_responded_column",
+    "add_dark_mode_column",
+    "add_is_active_to_group",
+)
 branch_labels = None
 depends_on = None
 

--- a/models/enums.py
+++ b/models/enums.py
@@ -171,6 +171,8 @@ class GroupAuditAction(Enum):
     FUNDS_WITHDRAWN = "funds_withdrawn"
     FUNDS_SET = "funds_set"
     DISBANDED = "disbanded"
+    DEACTIVATED = "deactivated"
+    ACTIVATED = "activated"
 
     @classmethod
     def descriptions(cls):
@@ -186,6 +188,8 @@ class GroupAuditAction(Enum):
             cls.FUNDS_WITHDRAWN.value: "Funds Withdrawn",
             cls.FUNDS_SET.value: "Funds Set",
             cls.DISBANDED.value: "Disbanded",
+            cls.DEACTIVATED.value: "Deactivated",
+            cls.ACTIVATED.value: "Activated",
         }
 
 

--- a/models/tools/group.py
+++ b/models/tools/group.py
@@ -11,6 +11,7 @@ class Group(db.Model):
     bank_account = db.Column(db.Integer, nullable=False, default=0)
     group_pack = db.Column(db.String, nullable=True)  # JSON string
     pack_complete = db.Column(db.Boolean, nullable=False, default=False)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
     created_at = db.Column(db.DateTime, nullable=False, default=db.func.now())
     updated_at = db.Column(
         db.DateTime, nullable=False, default=db.func.now(), onupdate=db.func.now()
@@ -64,6 +65,28 @@ class Group(db.Model):
             editor_user_id=editor_user_id,
             action=GroupAuditAction.FUNDS_SET,
             changes=f"Funds set from {old_balance} to {new_balance} for {reason}",
+        )
+        db.session.add(audit_log)
+
+    def deactivate(self, editor_user_id, reason):
+        """Deactivate the group with audit logging."""
+        self.is_active = False
+        audit_log = GroupAuditLog(
+            group_id=self.id,
+            editor_user_id=editor_user_id,
+            action=GroupAuditAction.DEACTIVATED,
+            changes=f"Group deactivated: {reason}",
+        )
+        db.session.add(audit_log)
+
+    def activate(self, editor_user_id, reason):
+        """Activate the group with audit logging."""
+        self.is_active = True
+        audit_log = GroupAuditLog(
+            group_id=self.id,
+            editor_user_id=editor_user_id,
+            action=GroupAuditAction.ACTIVATED,
+            changes=f"Group activated: {reason}",
         )
         db.session.add(audit_log)
 

--- a/routes/tools/groups.py
+++ b/routes/tools/groups.py
@@ -28,9 +28,16 @@ def group_list():
     )
 
     if is_admin_and_wants_admin_view:
-        groups = Group.query.all()
+        show_inactive = request.args.get("show_inactive", "false") == "true"
+        if show_inactive:
+            groups = Group.query.all()
+        else:
+            groups = Group.query.filter_by(is_active=True).all()
         return render_template(
-            "groups/admin_list.html", groups=groups, group_types=GroupType.query.all()
+            "groups/admin_list.html",
+            groups=groups,
+            group_types=GroupType.query.all(),
+            show_inactive=show_inactive,
         )
 
     # From here, it's the user view (for non-admins, or admins who've switched)
@@ -62,6 +69,9 @@ def group_list():
         .filter(Character.group_id.is_(None), Character.faction_id == active_character.faction_id)
         .all()
     )
+
+    # Get active groups for the character's faction (for future use)
+    # active_groups = Group.query.filter_by(is_active=True).all()
 
     return render_template(
         "groups/list.html",
@@ -143,6 +153,15 @@ def edit_group_post(group_id):
     admin_view = request.form.get("admin_view")
     character_id = request.form.get("character_id")
 
+    # Prevent editing inactive groups (unless user is admin)
+    if not group.is_active and not current_user.has_role(Role.USER_ADMIN.value):
+        flash("Cannot edit inactive groups", "error")
+        if admin_view == "false":
+            return redirect(
+                url_for("groups.group_list", admin_view="false", character_id=character_id)
+            )
+        return redirect(url_for("groups.group_list"))
+
     if not name:
         flash("Name is required", "error")
         return redirect(url_for("groups.group_list"))
@@ -159,9 +178,18 @@ def edit_group_post(group_id):
         group.group_type_id = int(type)
 
     # Handle bank account changes using centralized methods
-    if current_user.has_role(Role.USER_ADMIN.value):
-        if group.bank_account != bank_account:
-            group.set_funds(bank_account, current_user.id, "Admin group edit")
+    if current_user.has_role(Role.USER_ADMIN.value) and bank_account:
+        try:
+            bank_account_int = int(bank_account)
+            if group.bank_account != bank_account_int:
+                group.set_funds(bank_account_int, current_user.id, "Admin group edit")
+        except ValueError:
+            flash("Bank account must be a number", "error")
+            if admin_view == "false":
+                return redirect(
+                    url_for("groups.group_list", admin_view="false", character_id=character_id)
+                )
+            return redirect(url_for("groups.group_list"))
 
     group.name = name
 
@@ -190,6 +218,15 @@ def invite_to_group(group_id):
     group = Group.query.get_or_404(group_id)
     admin_view = request.form.get("admin_view")
     redirect_character_id = request.form.get("redirect_character_id")
+
+    # Prevent inviting to inactive groups
+    if not group.is_active:
+        flash("Cannot invite to inactive groups", "error")
+        if admin_view == "false":
+            return redirect(
+                url_for("groups.group_list", admin_view="false", character_id=redirect_character_id)
+            )
+        return redirect(url_for("groups.group_list"))
 
     if redirect_character_id:
         character = Character.query.get_or_404(redirect_character_id)
@@ -371,29 +408,18 @@ def disband_group_post(group_id):
         flash("Cannot disband group with multiple members", "error")
         return redirect(url_for("groups.group_list", character_id=character_id))
 
-    # Create audit log for group disbanding
-    audit_log = GroupAuditLog(
-        group_id=group.id,
-        editor_user_id=current_user.id,
-        action=GroupAuditAction.DISBANDED.value,
-        changes=f"Group disbanded by {character.name}",
-    )
-    db.session.add(audit_log)
-
     # Remove character from group
     character.group_id = None
 
     # Delete all invites for this group
     GroupInvite.query.filter_by(group_id=group_id).delete()
 
-    # Delete all audit logs for this group
-    GroupAuditLog.query.filter_by(group_id=group_id).delete()
+    # Deactivate the group instead of deleting it
+    group.deactivate(current_user.id, f"Group disbanded by {character.name}")
 
-    # Delete the group
-    db.session.delete(group)
     db.session.commit()
 
-    flash("Group disbanded.", "success")
+    flash("Group disbanded and deactivated.", "success")
     return redirect(url_for("groups.group_list", admin_view=admin_view, character_id=character_id))
 
 
@@ -665,3 +691,67 @@ def group_audit_log(group_id):
         audit_logs=audit_logs,
         GroupAuditAction=GroupAuditAction,
     )
+
+
+@groups_bp.route("/<int:group_id>/activate", methods=["POST"])
+@login_required
+@email_verified_required
+def activate_group(group_id):
+    group = Group.query.get_or_404(group_id)
+    admin_view = request.form.get("admin_view")
+    character_id = request.form.get("character_id")
+
+    # Check if user is admin or if user has a character in this group
+    user_has_access = False
+    if current_user.has_role(Role.USER_ADMIN.value):
+        user_has_access = True
+    else:
+        # Check if any of user's characters are in this group
+        user_characters = Character.query.filter_by(user_id=current_user.id).all()
+        for character in user_characters:
+            if character.group_id == group.id:
+                user_has_access = True
+                break
+
+    if not user_has_access:
+        abort(403)
+
+    if group.is_active:
+        flash("Group is already active", "info")
+    else:
+        group.activate(current_user.id, "Group reactivated")
+        db.session.commit()
+        flash("Group activated successfully", "success")
+
+    if admin_view == "false":
+        return redirect(url_for("groups.group_list", admin_view="false", character_id=character_id))
+    return redirect(url_for("groups.group_list"))
+
+
+@groups_bp.route("/<int:group_id>/deactivate", methods=["POST"])
+@login_required
+@email_verified_required
+def deactivate_group(group_id):
+    group = Group.query.get_or_404(group_id)
+    admin_view = request.form.get("admin_view")
+    character_id = request.form.get("character_id")
+
+    # Only user-admins can deactivate groups with characters in them
+    if len(group.characters) > 0 and not current_user.has_role(Role.USER_ADMIN.value):
+        flash("Only administrators can deactivate groups with members", "error")
+        if admin_view == "false":
+            return redirect(
+                url_for("groups.group_list", admin_view="false", character_id=character_id)
+            )
+        return redirect(url_for("groups.group_list"))
+
+    if not group.is_active:
+        flash("Group is already inactive", "info")
+    else:
+        group.deactivate(current_user.id, "Group deactivated")
+        db.session.commit()
+        flash("Group deactivated successfully", "success")
+
+    if admin_view == "false":
+        return redirect(url_for("groups.group_list", admin_view="false", character_id=character_id))
+    return redirect(url_for("groups.group_list"))

--- a/templates/groups/admin_list.html
+++ b/templates/groups/admin_list.html
@@ -17,6 +17,21 @@
             </div>
         </div>
 
+        <div class="card mb-4">
+            <div class="card-body">
+                <form method="GET" class="d-flex align-items-center">
+                    <div class="form-check me-3">
+                        <input class="form-check-input" type="checkbox" id="show_inactive" name="show_inactive" value="true"
+                               {% if show_inactive %}checked{% endif %}>
+                        <label class="form-check-label" for="show_inactive">
+                            Show Inactive Groups
+                        </label>
+                    </div>
+                    <button type="submit" class="btn btn-outline-primary btn-sm">Apply Filter</button>
+                </form>
+            </div>
+        </div>
+
         <div class="card">
             <div class="card-body">
                 <table class="table">
@@ -27,6 +42,7 @@
                             <th>Bank Account</th>
                             <th>Members</th>
                             <th>Samples</th>
+                            <th>Status</th>
                             <th>Actions</th>
                         </tr>
                     </thead>
@@ -53,8 +69,24 @@
                                 {% endif %}
                             </td>
                             <td>
+                                {% if group.is_active %}
+                                    <span class="badge bg-success">Active</span>
+                                {% else %}
+                                    <span class="badge bg-secondary">Inactive</span>
+                                {% endif %}
+                            </td>
+                            <td>
                                 <a href="{{ url_for('groups.edit_group_admin', group_id=group.id) }}" class="btn btn-primary btn-sm">Edit</a>
                                 <a href="{{ url_for('groups.group_audit_log', group_id=group.id) }}" class="btn btn-info btn-sm">Audit Log</a>
+                                {% if group.is_active %}
+                                    <form method="POST" action="{{ url_for('groups.deactivate_group', group_id=group.id) }}" style="display: inline;">
+                                        <button type="submit" class="btn btn-warning btn-sm" onclick="return confirm('Are you sure you want to deactivate this group?')">Deactivate</button>
+                                    </form>
+                                {% else %}
+                                    <form method="POST" action="{{ url_for('groups.activate_group', group_id=group.id) }}" style="display: inline;">
+                                        <button type="submit" class="btn btn-success btn-sm">Activate</button>
+                                    </form>
+                                {% endif %}
                                 <button type="button" class="btn btn-danger btn-sm disband-btn" data-disband-url="{{ url_for('groups.disband_group_post', group_id=group.id) }}" data-warning="This action is not reversible and cannot be recovered.">Disband</button>
                             </td>
                         </tr>

--- a/templates/groups/list.html
+++ b/templates/groups/list.html
@@ -34,31 +34,42 @@
         <div class="card mb-4">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h2>Your Group</h2>
-                <a href="{{ url_for('groups.group_audit_log', group_id=character.group.id) }}" class="btn btn-outline-info">
-                    <i class="fas fa-history me-1"></i> View Audit Log
-                </a>
+                <div>
+                    {% if not character.group.is_active %}
+                        <span class="badge bg-warning me-2">Inactive</span>
+                    {% endif %}
+                    <a href="{{ url_for('groups.group_audit_log', group_id=character.group.id) }}" class="btn btn-outline-info">
+                        <i class="fas fa-history me-1"></i> View Audit Log
+                    </a>
+                </div>
             </div>
             <div class="card-body">
-                <form method="POST" action="{{ url_for('groups.edit_group_post', group_id=character.group.id) }}" class="mb-4">
-                    <input type="hidden" name="admin_view" value="false">
-                    <input type="hidden" name="character_id" value="{{ character.id }}">
-                    <div class="form-group mb-3">
-                        <label for="name">Group Name</label>
-                        <input type="text" class="form-control" id="name" name="name" value="{{ character.group.name }}" required>
-                    </div>
+                {% if character.group.is_active %}
+                    <form method="POST" action="{{ url_for('groups.edit_group_post', group_id=character.group.id) }}" class="mb-4">
+                        <input type="hidden" name="admin_view" value="false">
+                        <input type="hidden" name="character_id" value="{{ character.id }}">
+                        <div class="form-group mb-3">
+                            <label for="name">Group Name</label>
+                            <input type="text" class="form-control" id="name" name="name" value="{{ character.group.name }}" required>
+                        </div>
 
-                    <div class="form-group mb-3">
-                        <label>Group Type</label>
-                        <input type="text" class="form-control" value="{{ character.group.group_type.name }}" readonly>
-                    </div>
+                        <div class="form-group mb-3">
+                            <label>Group Type</label>
+                            <input type="text" class="form-control" value="{{ character.group.group_type.name }}" readonly>
+                        </div>
 
-                    <div class="form-group mb-3">
-                        <label>Bank Balance</label>
-                        <input type="text" class="form-control" value="{{ character.group.bank_account }}" readonly>
-                    </div>
+                        <div class="form-group mb-3">
+                            <label>Bank Balance</label>
+                            <input type="text" class="form-control" value="{{ character.group.bank_account }}" readonly>
+                        </div>
 
-                    <button type="submit" class="btn btn-primary">Update Group Name</button>
-                </form>
+                        <button type="submit" class="btn btn-primary">Update Group Name</button>
+                    </form>
+                {% else %}
+                    <div class="alert alert-warning">
+                        <strong>Group is inactive.</strong> You cannot edit an inactive group. Please reactivate it first.
+                    </div>
+                {% endif %}
 
                 <h3>Members</h3>
                 <table class="table">
@@ -91,36 +102,50 @@
                     {% endif %}
                 </div>
 
-                <div class="mt-4">
-                    <h3>Invite Character</h3>
-                    <form method="POST" action="{{ url_for('groups.invite_to_group', group_id=character.group.id) }}">
-                        <input type="hidden" name="admin_view" value="false">
-                        <input type="hidden" name="redirect_character_id" value="{{ character.id }}">
-                        <div class="input-group">
-                            <select class="form-control" name="character_id" required>
-                                <option value="">Select Character to Invite</option>
-                                {% for char in active_characters %}
-                                <option value="{{ char.id }}">{{ char.name }} ({{ char.faction.name }})</option>
-                                {% endfor %}
-                            </select>
-                            <button type="submit" class="btn btn-primary">Send Invite</button>
+                {% if character.group.is_active %}
+                    <div class="mt-4">
+                        <h3>Invite Character</h3>
+                        <form method="POST" action="{{ url_for('groups.invite_to_group', group_id=character.group.id) }}">
+                            <input type="hidden" name="admin_view" value="false">
+                            <input type="hidden" name="redirect_character_id" value="{{ character.id }}">
+                            <div class="input-group">
+                                <select class="form-control" name="character_id" required>
+                                    <option value="">Select Character to Invite</option>
+                                    {% for char in active_characters %}
+                                    <option value="{{ char.id }}">{{ char.name }} ({{ char.faction.name }})</option>
+                                    {% endfor %}
+                                </select>
+                                <button type="submit" class="btn btn-primary">Send Invite</button>
+                            </div>
+                        </form>
+                    </div>
+                {% else %}
+                    <div class="mt-4">
+                        <div class="alert alert-info">
+                            <strong>Group is inactive.</strong> You cannot invite characters to an inactive group.
                         </div>
-                    </form>
-                </div>
+                    </div>
+                {% endif %}
             </div>
             <div class="card-footer d-flex">
-                {% if character.group.characters|length > 1 %}
-                    <form method="POST" action="{{ url_for('groups.leave_group_post', group_id=character.group.id) }}" id="leaveGroupForm" class="mr-2">
-                        <input type="hidden" name="admin_view" value="false">
-                        <input type="hidden" name="character_id" value="{{ character.id }}">
-                        <button type="button" class="btn btn-warning confirmation-trigger" data-form="leaveGroupForm" data-message="Are you sure you want to leave the group?">Leave Group</button>
-                    </form>
+                {% if character.group.is_active %}
+                    {% if character.group.characters|length > 1 %}
+                        <form method="POST" action="{{ url_for('groups.leave_group_post', group_id=character.group.id) }}" id="leaveGroupForm" class="mr-2">
+                            <input type="hidden" name="admin_view" value="false">
+                            <input type="hidden" name="character_id" value="{{ character.id }}">
+                            <button type="button" class="btn btn-warning confirmation-trigger" data-form="leaveGroupForm" data-message="Are you sure you want to leave the group?">Leave Group</button>
+                        </form>
+                    {% else %}
+                        <form method="POST" action="{{ url_for('groups.disband_group_post', group_id=character.group.id) }}" id="disbandGroupForm-last-member" class="mr-2">
+                            <input type="hidden" name="admin_view" value="false">
+                            <input type="hidden" name="character_id" value="{{ character.id }}">
+                            <button type="button" class="btn btn-danger confirmation-trigger" data-form="disbandGroupForm-last-member" data-message="Are you sure you want to disband the group?">Disband Group</button>
+                        </form>
+                    {% endif %}
                 {% else %}
-                    <form method="POST" action="{{ url_for('groups.disband_group_post', group_id=character.group.id) }}" id="disbandGroupForm-last-member" class="mr-2">
-                        <input type="hidden" name="admin_view" value="false">
-                        <input type="hidden" name="character_id" value="{{ character.id }}">
-                        <button type="button" class="btn btn-danger confirmation-trigger" data-form="disbandGroupForm-last-member" data-message="Are you sure you want to disband the group?">Disband Group</button>
-                    </form>
+                    <div class="text-muted">
+                        <em>Group actions are disabled while the group is inactive.</em>
+                    </div>
                 {% endif %}
             </div>
         </div>
@@ -193,6 +218,23 @@
             </div>
         </div>
         {% endif %}
+    {% endif %}
+
+    <!-- Inactive Groups Section -->
+    {% if character.group and not character.group.is_active %}
+        <div class="card mb-4">
+            <div class="card-header bg-warning">
+                <h2>Inactive Group</h2>
+            </div>
+            <div class="card-body">
+                <p class="text-muted">Your group is currently inactive. You can reactivate it if you wish to continue using it.</p>
+                <form method="POST" action="{{ url_for('groups.activate_group', group_id=character.group.id) }}">
+                    <input type="hidden" name="admin_view" value="false">
+                    <input type="hidden" name="character_id" value="{{ character.id }}">
+                    <button type="submit" class="btn btn-success">Reactivate Group</button>
+                </form>
+            </div>
+        </div>
     {% endif %}
 </div>
 

--- a/tests/models/tools/test_group.py
+++ b/tests/models/tools/test_group.py
@@ -46,3 +46,36 @@ def test_new_group_with_invite(db, character):
     retrieved_invite = retrieved_group.invites[0]
     assert retrieved_invite.character_id == character.id
     assert retrieved_invite.group_id == group.id
+
+
+def test_group_activation_deactivation(db, character):
+    """Test group activation and deactivation functionality."""
+    # Create a group type first
+    group_type = GroupType(
+        name="Military",
+        description="A military group type",
+        income_items_list=[],
+        income_items_discount=0.5,
+        income_substances=False,
+        income_substance_cost=0,
+        income_medicaments=False,
+        income_medicament_cost=0,
+        income_distribution_dict={"items": 50, "chits": 50},
+    )
+    db.session.add(group_type)
+    db.session.commit()
+
+    group = Group(name="Test Group", group_type_id=group_type.id, bank_account=1000)
+    db.session.add(group)
+    db.session.commit()
+
+    # Test initial state
+    assert group.is_active is True
+
+    # Test deactivation
+    group.deactivate(1, "Test deactivation")
+    assert group.is_active is False
+
+    # Test activation
+    group.activate(1, "Test activation")
+    assert group.is_active is True

--- a/tests/routes/tools/test_groups.py
+++ b/tests/routes/tools/test_groups.py
@@ -249,8 +249,10 @@ def test_disband_group(test_client, new_user, db_session, military_group_type):
     data = {"character_id": character.id}
     resp = test_client.post(f"/groups/{group.id}/disband", data=data, follow_redirects=True)
     assert resp.status_code == 200
+    assert b"Group disbanded and deactivated" in resp.data
     disbanded_group = db_session.get(Group, group.id)
-    assert disbanded_group is None
+    assert disbanded_group is not None
+    assert disbanded_group.is_active is False
 
 
 def test_remove_character_admin(test_client, admin_user, db_session, military_group_type):
@@ -646,3 +648,301 @@ def test_group_audit_log_invite_declined(test_client, new_user, db_session, mili
     assert audit_log.action == GroupAuditAction.INVITE_DECLINED
     assert audit_log.editor_user_id == new_user.id
     assert "Invite declined by Char" in audit_log.changes
+
+
+def test_activate_group_admin(test_client, admin_user, db_session, military_group_type):
+    """Test that admins can activate inactive groups"""
+    group = Group(
+        name="Inactive Group", group_type_id=military_group_type.id, bank_account=0, is_active=False
+    )
+    db_session.add(group)
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = admin_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.post(f"/groups/{group.id}/activate", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Group activated successfully" in resp.data
+
+    db_session.refresh(group)
+    assert group.is_active is True
+
+
+def test_activate_group_member(test_client, new_user, db_session, military_group_type):
+    """Test that group members can activate their inactive group"""
+    group = Group(
+        name="Inactive Group", group_type_id=military_group_type.id, bank_account=0, is_active=False
+    )
+    character = Character(name="Char", user_id=new_user.id, status=CharacterStatus.ACTIVE.value)
+    db_session.add_all([group, character])
+    db_session.commit()
+    character.group_id = group.id
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = new_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.post(f"/groups/{group.id}/activate", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Group activated successfully" in resp.data
+
+    db_session.refresh(group)
+    assert group.is_active is True
+
+
+def test_activate_group_unauthorized(test_client, new_user, db_session, military_group_type):
+    """Test that non-members cannot activate groups"""
+    group = Group(
+        name="Inactive Group", group_type_id=military_group_type.id, bank_account=0, is_active=False
+    )
+    db_session.add(group)
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = new_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.post(f"/groups/{group.id}/activate", follow_redirects=True)
+    assert resp.status_code == 403
+
+
+def test_deactivate_group_admin(test_client, admin_user, db_session, military_group_type):
+    """Test that admins can deactivate groups"""
+    group = Group(
+        name="Active Group", group_type_id=military_group_type.id, bank_account=0, is_active=True
+    )
+    db_session.add(group)
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = admin_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.post(f"/groups/{group.id}/deactivate", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Group deactivated successfully" in resp.data
+
+    db_session.refresh(group)
+    assert group.is_active is False
+
+
+def test_deactivate_group_with_members_admin(
+    test_client, admin_user, db_session, military_group_type
+):
+    """Test that admins can deactivate groups with members"""
+    group = Group(
+        name="Active Group", group_type_id=military_group_type.id, bank_account=0, is_active=True
+    )
+    character = Character(name="Char", user_id=admin_user.id, status=CharacterStatus.ACTIVE.value)
+    db_session.add_all([group, character])
+    db_session.commit()
+    character.group_id = group.id
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = admin_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.post(f"/groups/{group.id}/deactivate", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Group deactivated successfully" in resp.data
+
+    db_session.refresh(group)
+    assert group.is_active is False
+
+
+def test_deactivate_group_with_members_regular_user(
+    test_client, new_user, db_session, military_group_type
+):
+    """Test that regular users cannot deactivate groups with members"""
+    group = Group(
+        name="Active Group", group_type_id=military_group_type.id, bank_account=0, is_active=True
+    )
+    character = Character(name="Char", user_id=new_user.id, status=CharacterStatus.ACTIVE.value)
+    db_session.add_all([group, character])
+    db_session.commit()
+    character.group_id = group.id
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = new_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.post(f"/groups/{group.id}/deactivate", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Only administrators can deactivate groups with members" in resp.data
+
+    db_session.refresh(group)
+    assert group.is_active is True
+
+
+def test_deactivate_empty_group_regular_user(
+    test_client, new_user, db_session, military_group_type
+):
+    """Test that regular users can deactivate empty groups"""
+    group = Group(
+        name="Empty Group", group_type_id=military_group_type.id, bank_account=0, is_active=True
+    )
+    db_session.add(group)
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = new_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.post(f"/groups/{group.id}/deactivate", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Group deactivated successfully" in resp.data
+
+    db_session.refresh(group)
+    assert group.is_active is False
+
+
+def test_disband_group_deactivates(test_client, new_user, db_session, military_group_type):
+    """Test that disbanding a group deactivates it instead of deleting"""
+    group = Group(
+        name="Disband Group", group_type_id=military_group_type.id, bank_account=0, is_active=True
+    )
+    character = Character(name="Char", user_id=new_user.id, status=CharacterStatus.ACTIVE.value)
+    db_session.add_all([group, character])
+    db_session.commit()
+    character.group_id = group.id
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = new_user.id
+        sess["_fresh"] = True
+
+    data = {"character_id": character.id}
+    resp = test_client.post(f"/groups/{group.id}/disband", data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Group disbanded and deactivated" in resp.data
+
+    # Group should still exist but be inactive
+    db_session.refresh(group)
+    assert group.is_active is False
+    assert character.group_id is None
+
+
+def test_admin_list_shows_active_only_by_default(
+    test_client, admin_user, db_session, military_group_type
+):
+    """Test that admin list shows only active groups by default"""
+    active_group = Group(
+        name="Active Group", group_type_id=military_group_type.id, bank_account=0, is_active=True
+    )
+    inactive_group = Group(
+        name="Inactive Group", group_type_id=military_group_type.id, bank_account=0, is_active=False
+    )
+    db_session.add_all([active_group, inactive_group])
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = admin_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.get("/groups/")
+    assert resp.status_code == 200
+
+    # Check that only the active group appears in the table
+    assert b"Active Group" in resp.data
+    # The inactive group should not appear in the table body
+    table_content = resp.data.decode("utf-8")
+    table_start = table_content.find("<tbody>")
+    table_end = table_content.find("</tbody>")
+    if table_start != -1 and table_end != -1:
+        table_body = table_content[table_start:table_end]
+        assert (
+            "Inactive Group" not in table_body
+        ), f"Inactive group found in table body: {table_body}"
+    else:
+        assert "Inactive Group" not in table_content
+
+
+def test_admin_list_shows_inactive_when_requested(
+    test_client, admin_user, db_session, military_group_type
+):
+    """Test that admin list shows inactive groups when requested"""
+    active_group = Group(
+        name="Active Group", group_type_id=military_group_type.id, bank_account=0, is_active=True
+    )
+    inactive_group = Group(
+        name="Inactive Group", group_type_id=military_group_type.id, bank_account=0, is_active=False
+    )
+    db_session.add_all([active_group, inactive_group])
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = admin_user.id
+        sess["_fresh"] = True
+
+    resp = test_client.get("/groups/?show_inactive=true")
+    assert resp.status_code == 200
+    assert b"Active Group" in resp.data
+    assert b"Inactive Group" in resp.data
+
+
+def test_edit_inactive_group_denied(test_client, new_user, db_session, military_group_type):
+    """Test that editing inactive groups is denied for regular users"""
+    group = Group(
+        name="Inactive Group", group_type_id=military_group_type.id, bank_account=0, is_active=False
+    )
+    character = Character(name="Char", user_id=new_user.id, status=CharacterStatus.ACTIVE.value)
+    db_session.add_all([group, character])
+    db_session.commit()
+    character.group_id = group.id
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = new_user.id
+        sess["_fresh"] = True
+
+    data = {"name": "Updated Name", "character_id": character.id}
+    resp = test_client.post(f"/groups/{group.id}/edit", data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Cannot edit inactive groups" in resp.data
+
+
+def test_edit_inactive_group_admin_allowed(
+    test_client, admin_user, db_session, military_group_type
+):
+    """Test that admins can edit inactive groups"""
+    group = Group(
+        name="Inactive Group", group_type_id=military_group_type.id, bank_account=0, is_active=False
+    )
+    db_session.add(group)
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = admin_user.id
+        sess["_fresh"] = True
+
+    data = {"name": "Updated Name"}
+    resp = test_client.post(f"/groups/{group.id}/edit", data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Group updated successfully" in resp.data
+
+
+def test_invite_to_inactive_group_denied(test_client, new_user, db_session, military_group_type):
+    """Test that inviting to inactive groups is denied"""
+    group = Group(
+        name="Inactive Group", group_type_id=military_group_type.id, bank_account=0, is_active=False
+    )
+    character = Character(name="Char", user_id=new_user.id, status=CharacterStatus.ACTIVE.value)
+    invitee = Character(name="Invitee", user_id=new_user.id, status=CharacterStatus.ACTIVE.value)
+    db_session.add_all([group, character, invitee])
+    db_session.commit()
+    character.group_id = group.id
+    db_session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["_user_id"] = new_user.id
+        sess["_fresh"] = True
+
+    data = {"character_id": invitee.id, "redirect_character_id": character.id}
+    resp = test_client.post(f"/groups/{group.id}/invite", data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Cannot invite to inactive groups" in resp.data


### PR DESCRIPTION
- Add is_active field to Group model with default True
- Create database migration for is_active column
- Add ACTIVATED and DEACTIVATED to GroupAuditAction enum
- Add activate() and deactivate() methods to Group model
- Update disband_group_post to deactivate instead of delete
- Add /groups/<id>/activate and /groups/<id>/deactivate routes
- Update admin list to filter by active status with show_inactive option
- Update user templates to show inactive group status
- Prevent editing/inviting to inactive groups
- Add comprehensive unit tests for all new functionality
- All existing tests pass

Fixes # (issue)
