### PR TITLE
Add reputation updates to manual review process

### DIFF
--- a/routes/tools/downtime.py
+++ b/routes/tools/downtime.py
@@ -630,6 +630,9 @@ def manual_review(period_id, character_id):
             question["faction"] = faction
             reputation_questions.append(question)
 
+    # Get all factions for reputation updates
+    factions = Faction.query.order_by(Faction.name).all()
+
     # Get data needed for research requirements
     item_types = [
         {"id": item.id, "name": item.name, "id_prefix": item.id_prefix}
@@ -660,6 +663,7 @@ def manual_review(period_id, character_id):
         invention=invention,
         invention_index=invention_index,
         reputation_questions=reputation_questions,
+        factions=factions,
         review_data=pack.review_data or {},
         item_types=item_types,
         exotics=exotics,
@@ -687,6 +691,25 @@ def manual_review_post(period_id, character_id):
     review_data = dict(pack.review_data or {})
 
     print("STAGES_JSON from form:", request.form.get("stages_json"))
+
+    # Handle reputation changes
+    reputation_changes = {}
+    for key, value in request.form.items():
+        if key.startswith("reputation_") and key != "reputation_question":
+            try:
+                faction_id = int(key.split("_")[1])
+                new_value = int(value)
+                current_value = pack.character.get_reputation(faction_id)
+                if new_value != current_value:
+                    reputation_changes[faction_id] = {
+                        "old_value": current_value,
+                        "new_value": new_value,
+                    }
+            except (ValueError, IndexError):
+                continue
+
+    if reputation_changes:
+        review_data["reputation_changes"] = reputation_changes
 
     # Handle invention review
     if "invention_review" in request.form:
@@ -1146,164 +1169,191 @@ def process_downtime(period_id):
 
     # Process manual entries
     for pack in packs:
-        for manual in pack.manual_entries:
-            if manual.get("type") == "invention_theory":
-                if manual.get("review_status") == "approved":
-                    if manual.get("invention_type") == "new":
-                        # Create new research project
-                        new_research = Research(
-                            project_name=manual.get("invention_name"),
-                            description=manual.get("invention_description"),
-                            created_by=pack.character.id,
+        if pack.review_data:
+            # Process invention reviews
+            if pack.review_data.get("invention_review") == "approve":
+                if pack.review_data.get("invention_type") == "new":
+                    # Create new research project
+                    new_research = Research(
+                        project_name=pack.review_data.get("invention_name"),
+                        description=pack.review_data.get("invention_description"),
+                        created_by=pack.character.id,
+                    )
+                    db.session.add(new_research)
+                    db.session.flush()  # Get the ID
+
+                    # Create stages and requirements
+                    stages_data = json.loads(pack.review_data.get("stages_json", "[]"))
+                    for stage_data in stages_data:
+                        stage = ResearchStage(
+                            research_id=new_research.id,
+                            stage_number=stage_data["stage_number"],
+                            name=stage_data["name"],
+                            description=stage_data["description"],
                         )
-                        db.session.add(new_research)
+                        db.session.add(stage)
                         db.session.flush()  # Get the ID
 
-                        # Create stages and requirements
-                        stages_data = json.loads(manual.get("stages_json", "[]"))
-                        for stage_data in stages_data:
-                            stage = ResearchStage(
-                                research_id=new_research.id,
-                                stage_number=stage_data["stage_number"],
-                                name=stage_data["name"],
-                                description=stage_data["description"],
+                        # Create requirements
+                        for req_data in stage_data["unlock_requirements"]:
+                            requirement = ResearchStageRequirement(
+                                stage_id=stage.id,
+                                requirement_type=req_data["requirement_type"],
+                                amount=req_data["amount"],
                             )
-                            db.session.add(stage)
-                            db.session.flush()  # Get the ID
 
-                            # Create requirements
-                            for req_data in stage_data["unlock_requirements"]:
-                                requirement = ResearchStageRequirement(
-                                    stage_id=stage.id,
-                                    requirement_type=req_data["requirement_type"],
-                                    amount=req_data["amount"],
+                            # Set type-specific fields
+                            if req_data["requirement_type"] == "science":
+                                requirement.science_type = req_data["science_type"]
+                            elif req_data["requirement_type"] == "item":
+                                requirement.item_type = req_data["item_type"]
+                            elif req_data["requirement_type"] == "exotic":
+                                requirement.exotic_substance_id = req_data["exotic_type"]
+                            elif req_data["requirement_type"] == "sample":
+                                requirement.sample_tag = req_data["sample_tag"]
+                                requirement.requires_researched = req_data.get(
+                                    "requires_researched", False
                                 )
 
-                                # Set type-specific fields
-                                if req_data["requirement_type"] == "science":
-                                    requirement.science_type = req_data["science_type"]
-                                elif req_data["requirement_type"] == "item":
-                                    requirement.item_type = req_data["item_type"]
-                                elif req_data["requirement_type"] == "exotic":
-                                    requirement.exotic_substance_id = req_data["exotic_type"]
-                                elif req_data["requirement_type"] == "sample":
-                                    requirement.sample_tag = req_data["sample_tag"]
-                                    requirement.requires_researched = req_data.get(
-                                        "requires_researched", False
-                                    )
+                            db.session.add(requirement)
 
-                                db.session.add(requirement)
+                    # Assign character to the research
+                    new_research.assign_character(pack.character.id)
+                    pack.character.pack.add_downtime_result(
+                        str(pack.id), f"New project confirmed: {new_research.project_name}"
+                    )
 
-                        # Assign character to the research
-                        new_research.assign_character(pack.character.id)
-                        pack.character.pack.add_downtime_result(
-                            str(pack.id), f"New project confirmed: {new_research.project_name}"
-                        )
+                elif pack.review_data.get("invention_type") == "improve":
+                    # Get the existing research project
+                    existing_research = Research.query.filter_by(
+                        id=pack.review_data.get("existing_invention")
+                    ).first()
 
-                    elif manual.get("invention_type") == "improve":
-                        # Get the existing research project
-                        existing_research = Research.query.filter_by(
-                            id=manual.get("existing_invention")
+                    if existing_research:
+                        # Get character's research
+                        char_research = CharacterResearch.query.filter_by(
+                            research_id=existing_research.id,
+                            character_id=pack.character.id,
                         ).first()
 
-                        if existing_research:
-                            # Get character's research
-                            char_research = CharacterResearch.query.filter_by(
-                                research_id=existing_research.id,
-                                character_id=pack.character.id,
-                            ).first()
+                        if char_research:
+                            # Verify all previous stages are complete
+                            all_complete = True
+                            for stage in char_research.stages:
+                                if not stage.stage_completed:
+                                    all_complete = False
+                                    break
 
-                            if char_research:
-                                # Verify all previous stages are complete
-                                all_complete = True
-                                for stage in char_research.stages:
-                                    if not stage.stage_completed:
-                                        all_complete = False
-                                        break
+                            if all_complete:
+                                # Create new stage
+                                stages_data = json.loads(pack.review_data.get("stages_json", "[]"))
+                                if stages_data:
+                                    new_stage_data = stages_data[
+                                        0
+                                    ]  # Only use first stage for improvement
+                                    new_stage = ResearchStage(
+                                        research_id=existing_research.id,
+                                        stage_number=len(existing_research.stages) + 1,
+                                        name=new_stage_data["name"],
+                                        description=new_stage_data["description"],
+                                    )
+                                    db.session.add(new_stage)
+                                    db.session.flush()
 
-                                if all_complete:
-                                    # Create new stage
-                                    stages_data = json.loads(manual.get("stages_json", "[]"))
-                                    if stages_data:
-                                        new_stage_data = stages_data[
-                                            0
-                                        ]  # Only use first stage for improvement
-                                        new_stage = ResearchStage(
-                                            research_id=existing_research.id,
-                                            stage_number=len(existing_research.stages) + 1,
-                                            name=new_stage_data["name"],
-                                            description=new_stage_data["description"],
+                                    # Create requirements
+                                    for req_data in new_stage_data["unlock_requirements"]:
+                                        requirement = ResearchStageRequirement(
+                                            stage_id=new_stage.id,
+                                            requirement_type=req_data["requirement_type"],
+                                            amount=req_data["amount"],
                                         )
-                                        db.session.add(new_stage)
-                                        db.session.flush()
 
-                                        # Create requirements
-                                        for req_data in new_stage_data["unlock_requirements"]:
-                                            requirement = ResearchStageRequirement(
-                                                stage_id=new_stage.id,
-                                                requirement_type=req_data["requirement_type"],
-                                                amount=req_data["amount"],
+                                        # Set type-specific fields
+                                        if req_data["requirement_type"] == "science":
+                                            requirement.science_type = req_data["science_type"]
+                                        elif req_data["requirement_type"] == "item":
+                                            requirement.item_type = req_data["item_type"]
+                                        elif req_data["requirement_type"] == "exotic":
+                                            requirement.exotic_substance_id = req_data[
+                                                "exotic_type"
+                                            ]
+                                        elif req_data["requirement_type"] == "sample":
+                                            requirement.sample_tag = req_data["sample_tag"]
+                                            requirement.requires_researched = req_data.get(
+                                                "requires_researched", False
                                             )
 
-                                            # Set type-specific fields
-                                            if req_data["requirement_type"] == "science":
-                                                requirement.science_type = req_data["science_type"]
-                                            elif req_data["requirement_type"] == "item":
-                                                requirement.item_type = req_data["item_type"]
-                                            elif req_data["requirement_type"] == "exotic":
-                                                requirement.exotic_substance_id = req_data[
-                                                    "exotic_type"
-                                                ]
-                                            elif req_data["requirement_type"] == "sample":
-                                                requirement.sample_tag = req_data["sample_tag"]
-                                                requirement.requires_researched = req_data.get(
-                                                    "requires_researched", False
-                                                )
+                                        db.session.add(requirement)
 
-                                            db.session.add(requirement)
+                                    # Create character's stage
+                                    char_stage = CharacterResearchStage(
+                                        character_research_id=char_research.id,
+                                        stage_id=new_stage.id,
+                                    )
+                                    db.session.add(char_stage)
 
-                                        # Create character's stage
-                                        char_stage = CharacterResearchStage(
-                                            character_research_id=char_research.id,
-                                            stage_id=new_stage.id,
-                                        )
-                                        db.session.add(char_stage)
+                                    # Set as current stage
+                                    char_research.current_stage_id = new_stage.id
 
-                                        # Set as current stage
-                                        char_research.current_stage_id = new_stage.id
-
-                                        pack.character.pack.add_downtime_result(
-                                            str(pack.id),
-                                            f"Improved {existing_research.project_name}",
-                                        )
-                elif manual.get("review_status") == "declined":
-                    # Add decline reason to character's pack
-                    if "messages" not in pack.character.character_pack:
-                        pack.character.character_pack["messages"] = []
-
-                    pack.character.character_pack["messages"].append(
-                        {
-                            "type": "invention_declined",
-                            "content": (
-                                f"Invention '{manual.get('invention_name')}' was declined: "
-                                f"{manual.get('invention_response')}"
-                            ),
-                        }
-                    )
-            elif manual.get("type") == "reputation_response":
-                # Add reputation response to character's pack
+                                    pack.character.pack.add_downtime_result(
+                                        str(pack.id),
+                                        f"Improved {existing_research.project_name}",
+                                    )
+            elif pack.review_data.get("invention_review") == "decline":
+                # Add decline reason to character's pack
                 if "messages" not in pack.character.character_pack:
                     pack.character.character_pack["messages"] = []
 
                 pack.character.character_pack["messages"].append(
                     {
-                        "type": "reputation_response",
+                        "type": "invention_declined",
                         "content": (
-                            f"Reputation response for {manual.get('faction_name')}: "
-                            f"{manual.get('response')}"
+                            f"Invention '{pack.review_data.get('invention_name')}' was declined: "
+                            f"{pack.review_data.get('invention_response')}"
                         ),
                     }
                 )
+
+            # Process reputation question responses
+            for key, value in pack.review_data.items():
+                if key.startswith("reputation_response_"):
+                    faction_id = key.split("_")[2]
+                    faction = db.session.get(Faction, int(faction_id))
+                    if faction:
+                        # Add reputation response to character's pack
+                        if "messages" not in pack.character.character_pack:
+                            pack.character.character_pack["messages"] = []
+
+                        pack.character.character_pack["messages"].append(
+                            {
+                                "type": "reputation_response",
+                                "content": (f"Reputation response for {faction.name}: " f"{value}"),
+                            }
+                        )
+
+    # Process reputation changes from manual review
+    for pack in packs:
+        if pack.review_data and pack.review_data.get("reputation_changes"):
+            for faction_id, change_data in pack.review_data["reputation_changes"].items():
+                try:
+                    faction_id_int = int(faction_id)
+                    faction = db.session.get(Faction, faction_id_int)
+                    if faction:
+                        old_value = change_data["old_value"]
+                        new_value = change_data["new_value"]
+
+                        # Update the character's reputation
+                        pack.character.set_reputation(faction_id_int, new_value, current_user.id)
+
+                        # Add to downtime results
+                        pack.character.pack.add_downtime_result(
+                            str(pack.id),
+                            f"Reputation with {faction.name} changed from {old_value} "
+                            f"to {new_value}",
+                        )
+                except (ValueError, TypeError):
+                    # Skip invalid faction IDs
+                    continue
 
     # Process all research stages
     for pack in packs:

--- a/static/js/downtime/manual_review.js
+++ b/static/js/downtime/manual_review.js
@@ -30,6 +30,21 @@ $(document).ready(function() {
         form.submit();
     });
 
+    // Handle reputation changes
+    $('.reputation-input').on('input', function() {
+        const factionId = $(this).data('faction-id');
+        const originalValue = parseInt($(this).data('original-value'));
+        const currentValue = parseInt($(this).val()) || 0;
+
+        if (currentValue !== originalValue) {
+            $(this).addClass('table-warning');
+            $(this).closest('tr').addClass('table-warning');
+        } else {
+            $(this).removeClass('table-warning');
+            $(this).closest('tr').removeClass('table-warning');
+        }
+    });
+
     // Initialize approve/decline options for the single invention
     function updateApproveDeclineUI() {
         const approveChecked = $("#approve").is(":checked");

--- a/templates/downtime/manual_review.html
+++ b/templates/downtime/manual_review.html
@@ -7,6 +7,48 @@
     <h1>Manual Review - {{ character.name }}</h1>
 
     <form method="POST" id="manual-review-form">
+        <!-- Update Reputations -->
+        <div class="card mb-4">
+            <div class="card-header">
+                <h2 class="h5 mb-0">Update Reputations</h2>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>Faction</th>
+                                <th style="width: 120px;">Current Reputation</th>
+                                <th style="width: 120px;">New Reputation</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for faction in factions %}
+                            <tr>
+                                <td>{{ faction.name }}</td>
+                                <td>
+                                    <span class="badge bg-secondary">{{ character.get_reputation(faction.id) }}</span>
+                                </td>
+                                <td>
+                                    <input type="number"
+                                           class="form-control form-control-sm reputation-input"
+                                           name="reputation_{{ faction.id }}"
+                                           value="{{ character.get_reputation(faction.id) }}"
+                                           data-faction-id="{{ faction.id }}"
+                                           data-original-value="{{ character.get_reputation(faction.id) }}">
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                <div class="form-text mt-2">
+                    <i class="fas fa-info-circle"></i>
+                    Update character reputations as needed. Changes will be applied when downtime is processed.
+                </div>
+            </div>
+        </div>
+
         <!-- Invention Reviews -->
         {% if invention %}
         <div class="card mb-4">

--- a/tests/routes/tools/test_downtime.py
+++ b/tests/routes/tools/test_downtime.py
@@ -668,6 +668,150 @@ def test_manual_review_with_other_field(
     assert downtime_pack_enter_downtime.status == DowntimeTaskStatus.COMPLETED
 
 
+def test_manual_review_reputation_changes(
+    test_client, downtime_pack_enter_downtime, downtime_team_user, db, faction
+):
+    """Test manual review with reputation changes."""
+    make_pack_manual_review(db, downtime_pack_enter_downtime)
+
+    # Set initial reputation
+    character = downtime_pack_enter_downtime.character
+    character.set_reputation(faction.id, 5, downtime_team_user.id)
+    db.session.commit()
+
+    login_user(test_client, downtime_team_user)
+
+    # Test with reputation change
+    response = test_client.post(
+        "/downtime/manual-review/"
+        f"{downtime_pack_enter_downtime.period_id}/"
+        f"{downtime_pack_enter_downtime.character_id}",
+        data={f"reputation_{faction.id}": "10", "confirm_complete": "on"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    # Verify pack was completed and review data contains reputation changes
+    db.session.refresh(downtime_pack_enter_downtime)
+    assert downtime_pack_enter_downtime.status == DowntimeTaskStatus.COMPLETED
+    assert "reputation_changes" in downtime_pack_enter_downtime.review_data
+    assert str(faction.id) in downtime_pack_enter_downtime.review_data["reputation_changes"]
+    assert (
+        downtime_pack_enter_downtime.review_data["reputation_changes"][str(faction.id)]["old_value"]
+        == 5
+    )
+    assert (
+        downtime_pack_enter_downtime.review_data["reputation_changes"][str(faction.id)]["new_value"]
+        == 10
+    )
+
+
+def test_manual_review_reputation_no_changes(
+    test_client, downtime_pack_enter_downtime, downtime_team_user, db, faction
+):
+    """Test manual review with no reputation changes."""
+    make_pack_manual_review(db, downtime_pack_enter_downtime)
+
+    # Set initial reputation
+    character = downtime_pack_enter_downtime.character
+    character.set_reputation(faction.id, 5, downtime_team_user.id)
+    db.session.commit()
+
+    login_user(test_client, downtime_team_user)
+
+    # Test with same reputation value (no change)
+    response = test_client.post(
+        "/downtime/manual-review/"
+        f"{downtime_pack_enter_downtime.period_id}/"
+        f"{downtime_pack_enter_downtime.character_id}",
+        data={f"reputation_{faction.id}": "5", "confirm_complete": "on"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    # Verify pack was completed but no reputation changes recorded
+    db.session.refresh(downtime_pack_enter_downtime)
+    assert downtime_pack_enter_downtime.status == DowntimeTaskStatus.COMPLETED
+    assert "reputation_changes" not in downtime_pack_enter_downtime.review_data
+
+
+def test_manual_review_reputation_multiple_factions(
+    test_client, downtime_pack_enter_downtime, downtime_team_user, db, faction
+):
+    """Test manual review with reputation changes for multiple factions."""
+    make_pack_manual_review(db, downtime_pack_enter_downtime)
+
+    # Create a second faction
+    from models.database.faction import Faction
+
+    faction2 = Faction(name="Test Faction 2", wiki_slug="test-faction-2")
+    db.session.add(faction2)
+    db.session.commit()
+
+    # Set initial reputations
+    character = downtime_pack_enter_downtime.character
+    character.set_reputation(faction.id, 5, downtime_team_user.id)
+    character.set_reputation(faction2.id, 0, downtime_team_user.id)  # No reputation initially
+    db.session.commit()
+
+    login_user(test_client, downtime_team_user)
+
+    # Test with reputation changes for both factions
+    response = test_client.post(
+        "/downtime/manual-review/"
+        f"{downtime_pack_enter_downtime.period_id}/"
+        f"{downtime_pack_enter_downtime.character_id}",
+        data={
+            f"reputation_{faction.id}": "10",
+            f"reputation_{faction2.id}": "3",
+            "confirm_complete": "on",
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    # Verify pack was completed and both reputation changes recorded
+    db.session.refresh(downtime_pack_enter_downtime)
+    assert "reputation_changes" in downtime_pack_enter_downtime.review_data
+
+    changes = downtime_pack_enter_downtime.review_data["reputation_changes"]
+    assert str(faction.id) in changes
+    assert str(faction2.id) in changes
+    assert changes[str(faction.id)]["old_value"] == 5
+    assert changes[str(faction.id)]["new_value"] == 10
+    assert changes[str(faction2.id)]["old_value"] == 0
+    assert changes[str(faction2.id)]["new_value"] == 3
+
+
+def test_manual_review_reputation_invalid_data(
+    test_client, downtime_pack_enter_downtime, downtime_team_user, db, faction
+):
+    """Test manual review with invalid reputation data."""
+    make_pack_manual_review(db, downtime_pack_enter_downtime)
+
+    login_user(test_client, downtime_team_user)
+
+    # Test with invalid faction ID
+    response = test_client.post(
+        "/downtime/manual-review/"
+        f"{downtime_pack_enter_downtime.period_id}/"
+        f"{downtime_pack_enter_downtime.character_id}",
+        data={"reputation_invalid": "10", "confirm_complete": "on"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    # Test with non-numeric value
+    response = test_client.post(
+        "/downtime/manual-review/"
+        f"{downtime_pack_enter_downtime.period_id}/"
+        f"{downtime_pack_enter_downtime.character_id}",
+        data={f"reputation_{faction.id}": "not_a_number", "confirm_complete": "on"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+
 def make_period_completed(db, downtime_period, downtime_pack):
     downtime_period.status = DowntimeStatus.COMPLETED
     downtime_pack.status = DowntimeTaskStatus.COMPLETED
@@ -911,3 +1055,127 @@ def create_test_event(db, event_number="TEST001"):
     db.session.add(event)
     db.session.commit()
     return event
+
+
+def test_process_downtime_with_reputation_changes(
+    test_client, downtime_team_user, downtime_period, downtime_pack, db, faction
+):
+    """Test processing downtime with reputation changes."""
+    # Create an event for the downtime period
+    from datetime import datetime, timedelta
+
+    from models.enums import EventType
+    from models.event import Event
+
+    event = Event(
+        event_number="TEST004",
+        name="Test Event",
+        event_type=EventType.MAINLINE,
+        early_booking_deadline=datetime.now() + timedelta(days=30),
+        booking_deadline=datetime.now() + timedelta(days=40),
+        start_date=datetime.now() + timedelta(days=60),
+        end_date=datetime.now() + timedelta(days=63),
+        standard_ticket_price=50.0,
+        early_booking_ticket_price=40.0,
+        child_ticket_price_12_15=25.0,
+        child_ticket_price_7_11=15.0,
+        child_ticket_price_under_7=0.0,
+    )
+    db.session.add(event)
+    db.session.commit()
+
+    # Associate the downtime period with the event
+    downtime_period.event_id = event.id
+
+    # Set up pack with reputation changes in review data
+    downtime_pack.status = DowntimeTaskStatus.COMPLETED
+    downtime_pack.review_data = {
+        "reputation_changes": {str(faction.id): {"old_value": 5, "new_value": 10}}
+    }
+
+    # Set initial reputation
+    character = downtime_pack.character
+    character.set_reputation(faction.id, 5, downtime_team_user.id)
+    db.session.commit()
+
+    login_user(test_client, downtime_team_user)
+
+    # Process downtime
+    response = test_client.post(f"/downtime/process/{downtime_period.id}")
+    assert response.status_code == 302  # Route redirects on success
+
+    # Verify reputation was updated
+    db.session.refresh(character)
+    assert character.get_reputation(faction.id) == 10
+
+    # Verify period was completed
+    db.session.refresh(downtime_period)
+    assert downtime_period.status == DowntimeStatus.COMPLETED
+
+
+def test_process_downtime_with_multiple_reputation_changes(
+    test_client, downtime_team_user, downtime_period, downtime_pack, db, faction
+):
+    """Test processing downtime with multiple reputation changes."""
+    # Create an event for the downtime period
+    from datetime import datetime, timedelta
+
+    from models.enums import EventType
+    from models.event import Event
+
+    event = Event(
+        event_number="TEST005",
+        name="Test Event",
+        event_type=EventType.MAINLINE,
+        early_booking_deadline=datetime.now() + timedelta(days=30),
+        booking_deadline=datetime.now() + timedelta(days=40),
+        start_date=datetime.now() + timedelta(days=60),
+        end_date=datetime.now() + timedelta(days=63),
+        standard_ticket_price=50.0,
+        early_booking_ticket_price=40.0,
+        child_ticket_price_12_15=25.0,
+        child_ticket_price_7_11=15.0,
+        child_ticket_price_under_7=0.0,
+    )
+    db.session.add(event)
+    db.session.commit()
+
+    # Associate the downtime period with the event
+    downtime_period.event_id = event.id
+
+    # Create a second faction
+    from models.database.faction import Faction
+
+    faction2 = Faction(name="Test Faction 2", wiki_slug="test-faction-2")
+    db.session.add(faction2)
+    db.session.commit()
+
+    # Set up pack with multiple reputation changes
+    downtime_pack.status = DowntimeTaskStatus.COMPLETED
+    downtime_pack.review_data = {
+        "reputation_changes": {
+            str(faction.id): {"old_value": 5, "new_value": 10},
+            str(faction2.id): {"old_value": 0, "new_value": 3},
+        }
+    }
+
+    # Set initial reputations
+    character = downtime_pack.character
+    character.set_reputation(faction.id, 5, downtime_team_user.id)
+    character.set_reputation(faction2.id, 0, downtime_team_user.id)
+    db.session.commit()
+
+    login_user(test_client, downtime_team_user)
+
+    # Process downtime
+    response = test_client.post(f"/downtime/process/{downtime_period.id}")
+    assert response.status_code == 302  # Route redirects on success
+
+    # Verify both reputations were updated
+    db.session.refresh(character)
+    assert character.get_reputation(faction.id) == 10
+    assert character.get_reputation(faction2.id) == 3
+
+    # Verify period was completed
+    db.session.refresh(downtime_period)
+    assert downtime_period.status == DowntimeStatus.COMPLETED


### PR DESCRIPTION
- Add new 'Update Reputations' section to manual review template
- Show character's current reputations across all factions
- Allow downtime team to update reputation values
- Save reputation changes to downtime pack review_data
- Process reputation changes during downtime processing
- Add comprehensive unit tests for the new functionality
- Update JavaScript to highlight changed reputation values

Fixes # (issue)
