### PR TITLE
Fix banking transfer 404 error when insufficient funds or invalid data

### DIFF
--- a/routes/tools/banking.py
+++ b/routes/tools/banking.py
@@ -160,6 +160,11 @@ def transfer():
         source_type = request.form.get("source_type")
         source_id = request.form.get("source_id")
 
+    # Validate required form data
+    if not source_type or not source_id or not target_type or not target_id:
+        flash("Please select both source and target accounts", "error")
+        return redirect(url_for("banking.bank"))
+
     try:
         amount = int(amount)
     except (ValueError, TypeError):
@@ -172,13 +177,19 @@ def transfer():
 
     # Get source account
     if source_type == "character":
-        source = Character.query.get_or_404(source_id)
+        source = Character.query.get(source_id)
+        if not source:
+            flash("Source character not found", "error")
+            return redirect(url_for("banking.bank"))
         if not current_user.has_permission("banking.manage") and source.user_id != current_user.id:
             flash("You do not have access to this account", "error")
             return redirect(url_for("banking.bank"))
         source_name = source.name
     else:
-        source = Group.query.get_or_404(source_id)
+        source = Group.query.get(source_id)
+        if not source:
+            flash("Source group not found", "error")
+            return redirect(url_for("banking.bank"))
         if not current_user.has_permission("banking.manage"):
             active_character = Character.query.filter_by(
                 user_id=current_user.id, status=CharacterStatus.ACTIVE.value
@@ -195,10 +206,16 @@ def transfer():
 
     # Get target account
     if target_type == "character":
-        target = Character.query.get_or_404(target_id)
+        target = Character.query.get(target_id)
+        if not target:
+            flash("Target character not found", "error")
+            return redirect(url_for("banking.bank"))
         target_name = target.name
     else:
-        target = Group.query.get_or_404(target_id)
+        target = Group.query.get(target_id)
+        if not target:
+            flash("Target group not found", "error")
+            return redirect(url_for("banking.bank"))
         target_name = target.name
 
     # Perform transfer using centralized methods

--- a/static/js/pages/banking.js
+++ b/static/js/pages/banking.js
@@ -56,24 +56,40 @@ $(document).ready(function() {
 
     // --- The rest of the banking logic (transfers, etc) can remain as needed ---
     // Handle source account selection
-    $('#source_type').change(function() {
+    $('#source_account').change(function() {
         var option = $(this).find('option:selected');
-        $('#source_id').val(option.data('id'));
+        var value = option.val();
+        if (value) {
+            var parts = value.split('_');
+            $('#source_type_hidden').val(parts[0]);
+            $('#source_id_hidden').val(parts[1]);
+        } else {
+            $('#source_type_hidden').val('');
+            $('#source_id_hidden').val('');
+        }
     });
 
     // Handle target account selection
-    $('#target_type').change(function() {
+    $('#target_account').change(function() {
         var option = $(this).find('option:selected');
-        $('#target_id').val(option.data('id'));
+        var value = option.val();
+        if (value) {
+            var parts = value.split('_');
+            $('#target_type_hidden').val(parts[0]);
+            $('#target_id_hidden').val(parts[1]);
+        } else {
+            $('#target_type_hidden').val('');
+            $('#target_id_hidden').val('');
+        }
     });
 
     // Validate amount against source balance
     $('form').submit(function(e) {
-        var sourceOption = $('#source_type option:selected');
+        var sourceOption = $('#source_account option:selected');
         var sourceBalance = parseFloat(sourceOption.data('balance'));
         var amount = parseFloat($('#amount').val());
 
-        if (amount > sourceBalance) {
+        if (sourceBalance && amount > sourceBalance) {
             e.preventDefault();
             alert('Insufficient funds in source account');
         }

--- a/templates/banking/bank.html
+++ b/templates/banking/bank.html
@@ -110,7 +110,7 @@
                             <select class="form-control select2" id="source_account" name="source_account" required title="Select source account for transfer">
                                 <option value="">Select source account...</option>
                                 {% for account in source_accounts %}
-                                <option value="{{ account.type }}_{{ account.id }}">
+                                <option value="{{ account.type }}_{{ account.id }}" data-balance="{{ account.balance }}">
                                     {{ account.name }} (Balance: {{ account.balance }})
                                 </option>
                                 {% endfor %}

--- a/tests/routes/tools/test_banking.py
+++ b/tests/routes/tools/test_banking.py
@@ -430,3 +430,60 @@ def test_transfer_between_own_characters(test_client, db, npc_user_with_chars):
 
     assert char1.bank_account == 850
     assert char2.bank_account == 650
+
+
+def test_transfer_insufficient_funds(test_client, db, npc_user_with_chars):
+    """
+    GIVEN a logged-in user trying to transfer more money than they have
+    WHEN they submit the transfer form
+    THEN they should get an error message instead of a 404
+    """
+    user, char1, char2 = npc_user_with_chars
+    char1.bank_account = 100  # Only 100 credits available
+    char2.bank_account = 500
+    db.session.commit()
+
+    with test_client.session_transaction() as session:
+        session["_user_id"] = user.id
+        session["_fresh"] = True
+
+    # Try to transfer 99999 credits (more than available)
+    transfer_data = {
+        "source_type_hidden": "character",
+        "source_id_hidden": char1.id,
+        "target_type_hidden": "character",
+        "target_id_hidden": char2.id,
+        "amount": "99999",
+    }
+    response = test_client.post("/banking/transfer", data=transfer_data, follow_redirects=True)
+    assert response.status_code == 200  # Should redirect back to banking page, not 404
+
+    # Check that balances are unchanged
+    db.session.refresh(char1)
+    db.session.refresh(char2)
+    assert char1.bank_account == 100  # Should be unchanged
+    assert char2.bank_account == 500  # Should be unchanged
+
+
+def test_transfer_missing_form_data(test_client, db, npc_user_with_chars):
+    """
+    GIVEN a logged-in user submitting incomplete form data
+    WHEN they submit the transfer form
+    THEN they should get an error message instead of a 404
+    """
+    user, char1, char2 = npc_user_with_chars
+
+    with test_client.session_transaction() as session:
+        session["_user_id"] = user.id
+        session["_fresh"] = True
+
+    # Submit form with missing target data
+    transfer_data = {
+        "source_type_hidden": "character",
+        "source_id_hidden": char1.id,
+        "target_type_hidden": "",  # Missing target type
+        "target_id_hidden": "",  # Missing target id
+        "amount": "100",
+    }
+    response = test_client.post("/banking/transfer", data=transfer_data, follow_redirects=True)
+    assert response.status_code == 200  # Should redirect back to banking page, not 404


### PR DESCRIPTION
- Replace get_or_404 with get() and proper error handling to prevent 404 errors
- Add validation for required form data before processing
- Fix JavaScript to properly populate hidden form fields
- Add data-balance attribute to source account options for client-side validation
- Add comprehensive tests for insufficient funds and missing form data scenarios

Fixes issue where users trying to transfer more credits than available would get a 404 error instead of an appropriate error message.

Fixes #155 
