### PR TITLE
feat: Show characters already in groups as disabled options in group …

### DIFF
--- a/routes/tools/groups.py
+++ b/routes/tools/groups.py
@@ -558,9 +558,9 @@ def remove_character(group_id, character_id):
 @permission_required(permissions=["group.edit"])
 def create_group_admin():
     if request.method == "GET":
-        # Get active characters that are not in any group
+        # Get all active characters (we'll show disabled ones in the template)
         available_characters = (
-            Character.query.filter_by(group_id=None, status=CharacterStatus.ACTIVE.value)
+            Character.query.filter_by(status=CharacterStatus.ACTIVE.value)
             .order_by(Character.name)
             .all()
         )
@@ -648,9 +648,9 @@ def create_group_admin():
 @permission_required(permissions=["group.edit"])
 def edit_group_admin(group_id):
     group = Group.query.get_or_404(group_id)
-    # Get active characters that are not in any group (available to add)
+    # Get all active characters (we'll show disabled ones in the template)
     available_characters = (
-        Character.query.filter_by(group_id=None, status=CharacterStatus.ACTIVE.value)
+        Character.query.filter_by(status=CharacterStatus.ACTIVE.value)
         .order_by(Character.name)
         .all()
     )
@@ -945,8 +945,7 @@ def api_characters_search():
     # Build the query
     characters_query = Character.query.filter_by(status=CharacterStatus.ACTIVE.value)
 
-    # Filter out characters already in groups
-    characters_query = characters_query.filter(Character.group_id.is_(None))
+    # Don't filter out characters already in groups - we'll show them as disabled
 
     # Check if query looks like user_id.character_id format
     if "." in query:
@@ -977,13 +976,22 @@ def api_characters_search():
     for character in characters:
         # Include user info in the text for better identification
         user_info = f"{character.user.first_name} {character.user.surname or ''}"
+
+        # Check if character is already in a group
+        is_in_group = character.group_id is not None
+        group_info = ""
+        if is_in_group:
+            group_info = f" (Already in {character.group.name})"
+
         items.append(
             {
                 "id": character.id,
-                "text": f"{character.name} ({character.faction.name}) - {user_info}",
+                "text": f"{character.name} ({character.faction.name}) - {user_info}{group_info}",
                 "name": character.name,
                 "faction": character.faction.name,
                 "user_info": user_info,
+                "disabled": is_in_group,
+                "group_name": character.group.name if is_in_group else None,
             }
         )
 

--- a/templates/groups/admin_edit.html
+++ b/templates/groups/admin_edit.html
@@ -131,7 +131,11 @@
                             <select class="form-control" name="character_id" required title="Select character to add to group">
                                 <option value="">Select a character...</option>
                                 {% for character in available_characters %}
-                                <option value="{{ character.id }}">{{ character.name }} ({{ character.faction.name }})</option>
+                                    {% if character.group_id %}
+                                        <option value="{{ character.id }}" disabled style="color: #999; font-style: italic;">{{ character.name }} ({{ character.faction.name }}) - Already in {{ character.group.name }}</option>
+                                    {% else %}
+                                        <option value="{{ character.id }}">{{ character.name }} ({{ character.faction.name }})</option>
+                                    {% endif %}
                                 {% endfor %}
                             </select>
                         </div>

--- a/templates/groups/list.html
+++ b/templates/groups/list.html
@@ -333,6 +333,12 @@ document.addEventListener('DOMContentLoaded', function() {
             width: '100%',
             placeholder: 'Search for a character to invite...',
             minimumInputLength: 2,
+            templateResult: function(item) {
+                if (item.disabled) {
+                    return $('<span style="color: #999; font-style: italic;">' + item.text + '</span>');
+                }
+                return item.text;
+            },
             ajax: {
                 url: '{{ url_for("groups.api_characters_search") }}',
                 dataType: 'json',
@@ -344,16 +350,33 @@ document.addEventListener('DOMContentLoaded', function() {
                     };
                 },
                 processResults: function(data) {
+                    // Sort items: available characters first, then disabled ones
+                    const sortedItems = data.items.sort(function(a, b) {
+                        if (a.disabled && !b.disabled) return 1;
+                        if (!a.disabled && b.disabled) return -1;
+                        return 0;
+                    });
+
                     return {
-                        results: data.items.map(function(item) {
+                        results: sortedItems.map(function(item) {
                             return {
                                 id: item.id,
-                                text: item.text
+                                text: item.text,
+                                disabled: item.disabled
                             };
                         })
                     };
                 },
                 cache: true
+            }
+        }).on('select2:select', function(e) {
+            // Prevent selection of disabled options
+            const data = e.params.data;
+            if (data.disabled) {
+                e.preventDefault();
+                $(this).val('').trigger('change');
+                alert('This character is already in a group and cannot be invited.');
+                return false;
             }
         }).on('select2:open', function() {
             // Apply dark mode styling if dark mode is active


### PR DESCRIPTION
…invitations

- Modified api_characters_search endpoint to include characters already in groups
- Added disabled flag and group information to API response
- Updated Select2 configuration to show disabled options with styling
- Added client-side validation to prevent selection of disabled options
- Updated admin group management to show disabled characters in dropdown
- Characters already in groups are now shown at the bottom of the list with italic styling
- Provides better user feedback about why certain characters cannot be invited

Fixes #160
